### PR TITLE
github: remove constraint for automated build at forks

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   run-uftrace-tests:
-    if: github.repository == 'namhyung/uftrace'
     runs-on: ubuntu-latest
     steps:
       - name: "checkout"

--- a/.github/workflows/on-demand-test.yml
+++ b/.github/workflows/on-demand-test.yml
@@ -20,7 +20,6 @@ on:
 
 jobs:
   run-uftrace-tests:
-    if: github.repository == 'namhyung/uftrace'
     runs-on: ubuntu-latest
     steps:
       - name: "checkout"


### PR DESCRIPTION
With the nightly and on-demand test target, a repository constraint restricts the github action execution from the forks.

However, by default, workflows are disabled in the forked repository. The action will be performed when the owner of the fork manually approves it to execute. (And the action will be executed within that user's own worker.)

Also, scheduled workflows are disabled by default in forks and to be enabled, user approval will be required. (And the action will be executed within that user's own worker.)

This commit removes the constraint for the automated build at forks.

Signed-off-by: Daniel T. Lee <danieltimlee@gmail.com>